### PR TITLE
Add codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
-on: [push]
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
 jobs:
   test:
     name: Run tests
@@ -9,10 +13,20 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
-    - uses: actions/checkout@v1
-    - name: Install build dependencies
-      shell: pwsh
-      run: ./install-build-dependencies.ps1
-    - name: Test
-      shell: pwsh
-      run: ./build.ps1 Test
+      - uses: actions/checkout@v1
+      - name: Install build dependencies
+        shell: pwsh
+        run: ./install-build-dependencies.ps1
+      - name: Test
+        shell: pwsh
+        run: ./build.ps1 Test
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          flags: unittests
+          env_vars: OS
+          name: codecov-umbrella
+          fail_ci_if_error: true
+          verbose: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,11 @@ jobs:
       - name: Test
         shell: pwsh
         run: ./build.ps1 Test
+      - name: Archive code coverage results
+        uses: actions/upload-artifact@v2
+        with:
+          name: code-coverage-report
+          path: ./coverage.xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Archive code coverage results
         uses: actions/upload-artifact@v2
         with:
-          name: code-coverage-report
+          name: code-coverage-report-${{ matrix.os }}
           path: ./coverage.xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,6 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
           flags: unittests
-          env_vars: OS
+          env_vars: RUNNER_OS
           name: codecov-umbrella
           fail_ci_if_error: true
-          verbose: true

--- a/build.ps1
+++ b/build.ps1
@@ -41,7 +41,7 @@ switch ($Task) {
         Path = (Join-Path $PSScriptRoot 'src' '*.ps1')
       }
       Output = @{
-        Verbosity = 'Detailed'
+        Verbosity = 'Diagnostic'
       }
     }
 

--- a/build.ps1
+++ b/build.ps1
@@ -29,6 +29,8 @@ $ErrorActionPreference = 'Stop'
 # Switch task
 switch ($Task) {
   'Test' {
+    Write-Host "Set path to be = $(Join-Path $PSScriptRoot 'src')"
+
     # Build Pester configuration
     $pesterConfiguration = @{
       Run = @{

--- a/build.ps1
+++ b/build.ps1
@@ -55,7 +55,7 @@ switch ($Task) {
 `$configuration = [PSCustomObject] [System.Management.Automation.PSSerializer]::Deserialize([System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String(`'$encodedConfiguration`')));
 Invoke-Pester -Configuration `$configuration
 "@
-    & pwsh -NoProfile -NoLogo -NonInteractive -Command "$command"
+    & pwsh -NoProfile -NoLogo -NonInteractive -WorkingDirectory $PSScriptRoot -Command "$command"
   }
 
   'Import' {

--- a/build.ps1
+++ b/build.ps1
@@ -36,6 +36,7 @@ switch ($Task) {
       }
       CodeCoverage = @{
         Enabled = $true
+        Path = (Join-Path $PSScriptRoot 'src' '*.ps1')
       }
       Output = @{
         Verbosity = 'Detailed'

--- a/build.ps1
+++ b/build.ps1
@@ -1,5 +1,5 @@
 #!/usr/bin/env pwsh
-#Requires -Version 7.0 -Modules @{ ModuleName='Pester'; ModuleVersion='5.1.1' }
+#Requires -Version 7.0 -Modules @{ ModuleName='Pester'; ModuleVersion='5.2' }
 
 <#
 .SYNOPSIS
@@ -29,8 +29,6 @@ $ErrorActionPreference = 'Stop'
 # Switch task
 switch ($Task) {
   'Test' {
-    Write-Host "Set path to be = $(Join-Path $PSScriptRoot 'src')"
-
     # Build Pester configuration
     $pesterConfiguration = @{
       Run = @{
@@ -38,10 +36,9 @@ switch ($Task) {
       }
       CodeCoverage = @{
         Enabled = $true
-        Path = (Join-Path $PSScriptRoot 'src' '*.ps1')
       }
       Output = @{
-        Verbosity = 'Diagnostic'
+        Verbosity = 'Detailed'
       }
     }
 

--- a/install-build-dependencies.ps1
+++ b/install-build-dependencies.ps1
@@ -19,9 +19,22 @@ if ($buildScriptAst.ScriptRequirements) {
       Scope = 'CurrentUser'
       Force = $true
     }
-    if ($_.Version)              { $params['MinimumVersion']  = $_.Version }
-    elseif ($_.RequiredVersion)  { $params['RequiredVersion'] = $_.RequiredVersion }
-    elseif ($_.MaximumVersion)   { $params['MaximumVersion']  = $_.MaximumVersion }
+
+    # Pester 5.1 has a bug preventing the codecoverage from being properly computed
+    # See https://github.com/pester/Pester/pull/1807
+    # The fix will be in 5.2 which has not been released yet and since PowerShell does not support
+    # semantic versioning 2.0 (😱), we cannot rely on an alpha version in build.ps1
+    # Temporarily force the alpha version here:
+    if ('Pester' -eq $params["Name"]) {
+      $params['RequiredVersion'] = '5.2.0-alpha3'
+      $params['AllowPrerelease'] = $true
+    }
+
+    else {
+      if ($_.Version)              { $params['MinimumVersion']  = $_.Version }
+      elseif ($_.RequiredVersion)  { $params['RequiredVersion'] = $_.RequiredVersion }
+      elseif ($_.MaximumVersion)   { $params['MaximumVersion']  = $_.MaximumVersion }
+    }
 
     # Install the module
     [PSCustomObject] $params | Format-Table


### PR DESCRIPTION
Add code coverage with codecov.io.

For that to work:

- Updated the (Actions) workflow to run on push and PR (push will be disabled eventually)
- Added a step to upload the artifacts (to GH) and to (Codecov)
- Dirty patched `install-build-dependencies.ps1` to rely in an alpha version of Pester 5.2 (to get code coverage to work)